### PR TITLE
Add node image display support to graph visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Here are the key resources used for data and development:
 - [GraphRAG for Python — neo4j-graphrag-python  documentation](https://neo4j.com/docs/neo4j-graphrag-python/current/index.html)
 - [Streamlit documentation](https://docs.streamlit.io/)
 - [ChrisDelClea/streamlit-agraph: A Streamlit Graph Vis](https://github.com/ChrisDelClea/streamlit-agraph)
+- [Vector Icons and Stickers - PNG, SVG, EPS, PSD and CSS](https://www.flaticon.com/)
 
 ## 🌟 Contribution
 We welcome contributions to improve PaperChainExplorer! Here are ways you can help:
@@ -128,6 +129,12 @@ We welcome contributions to improve PaperChainExplorer! Here are ways you can he
 
 ## 📜 License
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+## 📑 Attribution
+This project uses icons provided by Flaticon. Below are the specific attributions:
+- [Academic icons created by Slamlabs - Flaticon](https://www.flaticon.com/free-icons/academic)
+- [Graduation hat icons created by Freepik - Flaticon](https://www.flaticon.com/free-icons/graduation-hat)
+- [Institute icons created by vectorspoint - Flaticon](https://www.flaticon.com/free-icons/institute)
 
 <br>
 <br>
@@ -255,6 +262,7 @@ pytest tests/
 - [GraphRAG for Python — neo4j-graphrag-python  documentation](https://neo4j.com/docs/neo4j-graphrag-python/current/index.html)
 - [Streamlit documentation](https://docs.streamlit.io/)
 - [ChrisDelClea/streamlit-agraph: A Streamlit Graph Vis](https://github.com/ChrisDelClea/streamlit-agraph)
+- [Vector Icons and Stickers - PNG, SVG, EPS, PSD and CSS](https://www.flaticon.com/)
 
 ## 🌟 貢献
 PaperChainExplorer の改善への貢献を歓迎します！以下の方法でご協力いただけます：
@@ -264,3 +272,9 @@ PaperChainExplorer の改善への貢献を歓迎します！以下の方法で�
 
 ## 📜 ライセンス
 このプロジェクトは MIT ライセンスのです。詳細は [LICENSE](LICENSE) ファイルをご覧ください。
+
+## 📑 帰属表示
+このプロジェクトでは、Flaticon が提供するアイコンを使用しています。以下に具体的な帰属情報を記載します。
+- [Slamlabs によって作成された学術アイコン - Flaticon](https://www.flaticon.com/free-icons/academic)
+- [Freepik によって作成された卒業帽アイコン - Flaticon](https://www.flaticon.com/free-icons/graduation-hat)
+- [vectorspoint によって作成された施設アイコン - Flaticon](https://www.flaticon.com/free-icons/institute)

--- a/src/app.py
+++ b/src/app.py
@@ -99,9 +99,19 @@ embedder = OpenAIEmbeddings(model="text-embedding-3-small")
 def add_node(node: neo4j.graph.Node, label_key: str, nodes: list, id_history: set) -> None:
     node_id = node["id"]
     if node_id not in id_history:
+        if "Work" in node.labels:
+            image_url = "https://raw.githubusercontent.com/koyonkym/paper-chain-explorer/refs/heads/main/src/assets/icons/research-paper.png"
+        elif "Author" in node.labels:
+            image_url = "https://raw.githubusercontent.com/koyonkym/paper-chain-explorer/refs/heads/main/src/assets/icons/graduation-hat.png"
+        elif "Institution" in node.labels:
+            image_url = "https://raw.githubusercontent.com/koyonkym/paper-chain-explorer/refs/heads/main/src/assets/icons/institute.png"
+        else:
+            image_url = None
         node_data = {
             "id": node_id,
-            "title": node[label_key]
+            "title": node[label_key],
+            "shape": "circularImage",
+            "image": image_url
         }
         # Only set 'label' if the node is not of type 'Work'
         if "Work" not in node.labels:
@@ -185,3 +195,13 @@ if st.session_state.graph_data:
         edges=st.session_state.graph_data["edges"],
         config=st.session_state.graph_data["config"]
     )
+
+st.markdown(
+"""
+---
+### Attribution
+- [Academic icons created by Slamlabs - Flaticon](https://www.flaticon.com/free-icons/academic)
+- [Graduation hat icons created by Freepik - Flaticon](https://www.flaticon.com/free-icons/graduation-hat)
+- [Institute icons created by vectorspoint - Flaticon](https://www.flaticon.com/free-icons/institute)
+"""
+)


### PR DESCRIPTION
This PR introduces support for displaying images on nodes in the graph visualization. Key changes include:  

- **Image Rendering:** Nodes now support displaying images based on specified attributes.
- **Improved Readability:** Enhances graph clarity by visually distinguishing nodes.

This feature improves user experience by making it easier to interpret relationships in the Paper Chain Explorer.