### PR TITLE
Fix `ModuleNotFoundError` by Adjusting Import Path in `app.py`

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -9,7 +9,7 @@ from neo4j.exceptions import ServiceUnavailable
 from neo4j_graphrag.retrievers import Text2CypherRetriever
 from neo4j_graphrag.llm import OpenAILLM
 from neo4j_graphrag.embeddings import OpenAIEmbeddings
-from src.config import NEO4J_SCHEMA, EXAMPLES
+from config import NEO4J_SCHEMA, EXAMPLES
 
 
 # Function to load translations dynamically


### PR DESCRIPTION
This PR modifies the import statement in `app.py` to prevent a `ModuleNotFoundError` when running the app on Streamlit Cloud. The issue occurred because Streamlit Cloud does not recognize `src` as a module, while it worked locally in VSCode.
